### PR TITLE
Bugfix non utf 8 files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     resumable_upload (0.0.1)
+      bson (= 3.1.1)
       mongoid
       mongoid-grid_fs
       rails (~> 4.0.13)
@@ -34,7 +35,7 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
     arel (4.0.2)
-    bson (3.2.1)
+    bson (3.1.1)
     builder (3.1.4)
     byebug (5.0.0)
       columnize (= 0.9.0)
@@ -96,7 +97,7 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    sprockets (3.3.3)
+    sprockets (3.3.4)
       rack (~> 1.0)
     sprockets-rails (2.3.2)
       actionpack (>= 3.0)
@@ -116,6 +117,3 @@ DEPENDENCIES
   resumable_upload!
   rspec-rails
   sqlite3
-
-BUNDLED WITH
-   1.10.6

--- a/app/controllers/resumable_upload/chunks_controller.rb
+++ b/app/controllers/resumable_upload/chunks_controller.rb
@@ -31,6 +31,7 @@ module ResumableUpload
 
             #Create a target file
             target_file = Tempfile.new(params[:resumableFilename])
+            target_file.binmode
             for i in 1..params[:resumableChunkNumber].to_i
               #Select the chunk
               chunk = Mongoid::GridFs.find({"metadata.resumableFilename" => params[:resumableFilename],

--- a/resumable_upload.gemspec
+++ b/resumable_upload.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails", "~> 4.0.13"
+  s.add_dependency "bson", "3.1.1"
   s.add_dependency "mongoid"
   s.add_dependency "mongoid-grid_fs"
 


### PR DESCRIPTION
We were choking on non-UTF-8 files, so we're pinning BSON to 3.1.1 (because 3.1.2 tries to convert to UTF-8 before forcing binary), and setting `binmode` on the tempfile, so we can handle any character encoding.
