### PR TITLE
Slim down controller

### DIFF
--- a/app/controllers/resumable_upload/chunks_controller.rb
+++ b/app/controllers/resumable_upload/chunks_controller.rb
@@ -4,54 +4,23 @@ require 'stored_chunk'
 
 module ResumableUpload
   class ChunksController < ActionController::Base
-
     layout nil
 
-        #GET /chunk
-        def show
+    #GET /chunk
+    def show
+      if StoredChunk.exist(params[:resumableIdentifier], params[:resumableChunkNumber])
+        #Let resumable.js know this chunk already exists
+        render :nothing => true, :status => 200
+      else
+        #Let resumable.js know this chunk doesnt exists and needs to be uploaded
+        render :nothing => true, :status => 404
+      end
+    end
 
-          if StoredChunk.exist(params[:resumableFilename], params[:resumableChunkNumber])
-            #Let resumable.js know this chunk already exists
-            render :nothing => true, :status => 200
-          else
-            #Let resumable.js know this chunk doesnt exists and needs to be uploaded
-            render :nothing => true, :status => 404
-          end
-
-        end
-
-        #POST /chunk
-        def create
-          StoredChunk.save(params[:file].tempfile, params[:resumableFilename], params[:resumableChunkNumber])
-          #Concatenate all the partial files into the original file
-          currentSize = params[:resumableChunkNumber].to_i * params[:resumableChunkSize].to_i
-          filesize = params[:resumableTotalSize].to_i
-          #When all chunks are uploaded
-          if (currentSize + params[:resumableCurrentChunkSize].to_i) >= filesize
-
-            #Create a target file
-            target_file = Tempfile.new(params[:resumableFilename])
-            for i in 1..params[:resumableChunkNumber].to_i
-              #Select the chunk
-              chunk = Mongoid::GridFs.find({"metadata.resumableFilename" => params[:resumableFilename],
-                "metadata.resumableChunkNumber" => "#{i}"})
-              chunk.data.each_line do |line|
-                target_file.write(line)
-              end
-
-              #Deleting chunk
-              StoredChunk.destroy(chunk)
-            end
-
-            target_file.rewind
-
-            stored_csv = StoredCSV.save(target_file, params[:resumableFilename])
-
-            render json: { id: stored_csv.id.to_s }, :status => 200
-          else
-            render :nothing => true, :status => 200
-          end
-        end
-
+    #POST /chunk
+    def create
+      StoredChunk.save(params[:file].tempfile, params[:resumableIdentifier], params[:resumableChunkNumber])
+      render :nothing => true, :status => 200
+    end
   end
 end

--- a/spec/controllers/chunks_controller_spec.rb
+++ b/spec/controllers/chunks_controller_spec.rb
@@ -8,13 +8,13 @@ describe ResumableUpload::ChunksController, type: :controller do
   describe "GET 'show'" do
 
     it "returns 404 if chunk does not exist" do
-      get 'show', resumableFilename: "error", resumableChunkNumber: "error", :controller=>"resumable_upload/chunks"
+      get 'show', resumableIdentifier: "error", resumableChunkNumber: "error", :controller=>"resumable_upload/chunks"
       response.code.should == "404"
     end
 
     it "returns 200 if chunk exists" do
       stored_chunk = Mongoid::GridFs.put(Tempfile.new("return_200"))
-      stored_chunk.metadata = { resumableFilename: "spec_chunk", resumableChunkNumber: "0"}
+      stored_chunk.metadata = { resumableIdentifier: "spec_chunk", resumableChunkNumber: "0"}
       stored_chunk.save
       get 'show', resumableFilename: "spec_chunk", resumableChunkNumber: "0"
       response.code.should == "200"
@@ -26,17 +26,8 @@ describe ResumableUpload::ChunksController, type: :controller do
 
     it "concatenate a single chunk onto the chunk stack" do
       mock_file = mock_uploaded_file("chunks/spec_chunk.part1", nil)
-      post 'create', resumableFilename: "spec_chunk",
+      post 'create', resumableIdentifier: "spec_chunk",
         resumableChunkNumber: "1", resumableChunkSize: "5", resumableCurrentChunkSize: "5", resumableTotalSize: "100",
-        file: mock_file
-      response.code.should == "200"
-    end
-
-    it "complete file" do
-      mock_file = mock_uploaded_file("chunks/spec_chunk.part1", nil)
-      resumable_file_name = "spec_chunk"
-      post 'create', resumableFilename: resumable_file_name,
-        resumableChunkNumber: "1", resumableChunkSize: "5", resumableCurrentChunkSize: "5", resumableTotalSize: "1",
         file: mock_file
       response.code.should == "200"
     end


### PR DESCRIPTION
With large files, the joining operation can sometimes cause the frontend to timeout. We've slimmed down this process now, so all the joining up can be handled in a background process in the containing app.
